### PR TITLE
Removed the hikari pool

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -7,10 +7,6 @@ spring:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/code}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
     password: ${SPRING_DATASOURCE_PASSWORD:postgres}
-    hikari:
-      pool-name: code-pool
-      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:5}
-      allow-pool-suspension: false
 
   data:
     redis:


### PR DESCRIPTION
Most of the calls are made to Redis instead of The database, so it makes more sense to add to the redis pool instead of the hikari pool